### PR TITLE
Update Javadoc comments to fix several warnings

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/configuration/EvaluationConfiguration.java
+++ b/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/configuration/EvaluationConfiguration.java
@@ -26,74 +26,37 @@ import io.soabase.recordbuilder.core.RecordBuilder;
  * The configuration is used to instantiate pipeline components, each of which can access shared context
  * via a {@link edu.kit.kastel.sdq.lissa.ratlr.context.ContextStore} passed to their factory methods.
  * </p>
+ *
+ * @param cacheDir Directory for caching intermediate results.
+ * @param goldStandardConfiguration Configuration for gold standard evaluation.
+ * @param sourceArtifactProvider Configuration for the source artifact provider.
+ * @param targetArtifactProvider Configuration for the target artifact provider.
+ * @param sourcePreprocessor Configuration for the source artifact preprocessor.
+ * @param targetPreprocessor Configuration for the target artifact preprocessor.
+ * @param embeddingCreator Configuration for the embedding creator.
+ * @param sourceStore Configuration for the source element store.
+ * @param targetStore Configuration for the target element store.
+ * @param classifier Configuration for a single classifier.
+ *                  Either this or {@link #classifiers} must be set, but not both.
+ * @param classifiers Configuration for a multi-stage classifier pipeline.
+ *                   Either this or {@link #classifier} must be set, but not both.
+ * @param resultAggregator Configuration for the result aggregator.
+ * @param traceLinkIdPostprocessor Configuration for the trace link ID postprocessor.
  */
 @RecordBuilder()
 public record EvaluationConfiguration(
-        /**
-         * Directory for caching intermediate results.
-         */
         @JsonProperty("cache_dir") String cacheDir,
-
-        /**
-         * EvaluationConfiguration for gold standard evaluation.
-         */
         @JsonProperty("gold_standard_configuration") GoldStandardConfiguration goldStandardConfiguration,
-
-        /**
-         * EvaluationConfiguration for the source artifact provider.
-         */
         @JsonProperty("source_artifact_provider") ModuleConfiguration sourceArtifactProvider,
-
-        /**
-         * EvaluationConfiguration for the target artifact provider.
-         */
         @JsonProperty("target_artifact_provider") ModuleConfiguration targetArtifactProvider,
-
-        /**
-         * EvaluationConfiguration for the source artifact preprocessor.
-         */
         @JsonProperty("source_preprocessor") ModuleConfiguration sourcePreprocessor,
-
-        /**
-         * EvaluationConfiguration for the target artifact preprocessor.
-         */
         @JsonProperty("target_preprocessor") ModuleConfiguration targetPreprocessor,
-
-        /**
-         * EvaluationConfiguration for the embedding creator.
-         */
         @JsonProperty("embedding_creator") ModuleConfiguration embeddingCreator,
-
-        /**
-         * EvaluationConfiguration for the source element store.
-         */
         @JsonProperty("source_store") ModuleConfiguration sourceStore,
-
-        /**
-         * EvaluationConfiguration for the target element store.
-         */
         @JsonProperty("target_store") ModuleConfiguration targetStore,
-
-        /**
-         * EvaluationConfiguration for a single classifier.
-         * Either this or {@link #classifiers} must be set, but not both.
-         */
         @JsonProperty("classifier") @Nullable ModuleConfiguration classifier,
-
-        /**
-         * EvaluationConfiguration for a multi-stage classifier pipeline.
-         * Either this or {@link #classifier} must be set, but not both.
-         */
         @JsonProperty("classifiers") @Nullable List<List<ModuleConfiguration>> classifiers,
-
-        /**
-         * EvaluationConfiguration for the result aggregator.
-         */
         @JsonProperty("result_aggregator") ModuleConfiguration resultAggregator,
-
-        /**
-         * EvaluationConfiguration for the trace link ID postprocessor.
-         */
         @JsonProperty("tracelinkid_postprocessor") @Nullable ModuleConfiguration traceLinkIdPostprocessor)
         implements EvaluationConfigurationBuilder.With, SerializableConfiguration {
 

--- a/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/configuration/GoldStandardConfiguration.java
+++ b/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/configuration/GoldStandardConfiguration.java
@@ -15,25 +15,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * This record contains settings for loading and parsing gold standard data from a file.
  * The gold standard file is expected to be a CSV file containing trace links between
  * source and target elements.
+ *
+ * @param path Path to the gold standard file. The file should be a CSV file containing trace links.
+ * @param hasHeader Whether the gold standard file has a header row.
+ *                  If true, the first row will be skipped during parsing.
+ * @param swapColumns Whether to swap the source and target columns when reading the file.
+ *                    This is useful when the gold standard file has columns in a different order
+ *                    than expected by the system.
  */
 public record GoldStandardConfiguration(
-        /**
-         * Path to the gold standard file.
-         * The file should be a CSV file containing trace links.
-         */
         @JsonProperty("path") String path,
-
-        /**
-         * Whether the gold standard file has a header row.
-         * If true, the first row will be skipped during parsing.
-         */
         @JsonProperty(defaultValue = "false") boolean hasHeader,
 
-        /**
-         * Whether to swap the source and target columns when reading the file.
-         * This is useful when the gold standard file has columns in a different order
-         * than expected by the system.
-         */
         @JsonProperty(value = "swap_columns", defaultValue = "false")
         boolean swapColumns)
         implements Configuration {

--- a/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/context/ContextStore.java
+++ b/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/context/ContextStore.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.sdq.lissa.ratlr.context;
 
 import java.util.SortedMap;
@@ -41,6 +41,7 @@ public class ContextStore {
     /**
      * Retrieves a context by ID and type.
      *
+     * @param <C> the type of the context to retrieve
      * @param id the context ID
      * @param contextType the expected type of the context
      * @return the context instance if found and of the correct type, or null if not found

--- a/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/elementstore/ElementStoreOperations.java
+++ b/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/elementstore/ElementStoreOperations.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.sdq.lissa.ratlr.elementstore;
 
 import java.util.ArrayList;
@@ -20,6 +20,7 @@ public final class ElementStoreOperations {
      * Retrieves a subset of this source store to be used as training data for optimization.
      * The training data consists of the first size elements from the source store.
      *
+     * @param sourceElementStore The source element store
      * @param size The number of elements to include in the training source store
      * @return A new ElementStore containing only the training data elements
      */
@@ -32,7 +33,8 @@ public final class ElementStoreOperations {
      * Retrieves a subset of this target store that corresponds to the source store.
      * This method finds all elements in this target store that are similar to the elements in the source store.
      *
-     * @param sourceStore The training source element store
+     * @param targetElementStore The target element store
+     * @param sourceStore The source element store
      * @return A new ElementStore containing only the target elements that correspond to the source elements
      */
     public static TargetElementStore reduceTargetElementStore(

--- a/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/elementstore/strategy/CosineSimilarity.java
+++ b/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/elementstore/strategy/CosineSimilarity.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.sdq.lissa.ratlr.elementstore.strategy;
 
 import java.util.ArrayList;
@@ -23,6 +23,13 @@ public class CosineSimilarity implements RetrievalStrategy {
 
     private final int maxResults;
 
+    /**
+     * Constructs a CosineSimilarity retrieval strategy with the specified configuration.
+     * The configuration may specify the maximum number of results to return using the "max_results" argument.
+     * The value must be a positive integer or the special value {@value #MAX_RESULTS_INFINITY_ARGUMENT} to indicate no limit.
+     *
+     * @param configuration The configuration for the retrieval strategy
+     */
     public CosineSimilarity(ModuleConfiguration configuration) {
         final String maxResultsKey = "max_results";
         boolean isInfinity = configuration.hasArgument(maxResultsKey)

--- a/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/elementstore/strategy/RetrievalStrategy.java
+++ b/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/elementstore/strategy/RetrievalStrategy.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.sdq.lissa.ratlr.elementstore.strategy;
 
 import java.util.List;
@@ -10,12 +10,29 @@ import edu.kit.kastel.sdq.lissa.ratlr.configuration.ModuleConfiguration;
 import edu.kit.kastel.sdq.lissa.ratlr.knowledge.Element;
 import edu.kit.kastel.sdq.lissa.ratlr.utils.Pair;
 
+/**
+ * Interface defining the contract for retrieval strategies used to find similar elements based on their vector representations.
+ */
 public interface RetrievalStrategy {
     Logger logger = LoggerFactory.getLogger(RetrievalStrategy.class);
 
+    /**
+     * Finds similar elements to the given query element based on their vector representations.
+     *
+     * @param query The query element and its vector representation
+     * @param allElementsInStore A list of all elements in the store along with their vector representations
+     * @return A list of pairs containing similar elements and their similarity scores, sorted by similarity in descending order
+     */
     List<Pair<Element, Float>> findSimilarElements(
             Pair<Element, float[]> query, List<Pair<Element, float[]>> allElementsInStore);
 
+    /**
+     * Factory method to create an instance of RetrievalStrategy based on the provided configuration.
+     * This method uses the configuration name to determine which specific retrieval strategy implementation to instantiate.
+     *
+     * @param configuration The configuration for the retrieval strategy
+     * @return An instance of RetrievalStrategy based on the configuration
+     */
     static RetrievalStrategy createStrategy(ModuleConfiguration configuration) {
         return switch (configuration.name()) {
             case "cosine_similarity" -> new CosineSimilarity(configuration);

--- a/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/utils/Pair.java
+++ b/src/main/java/edu/kit/kastel/sdq/lissa/ratlr/utils/Pair.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.sdq.lissa.ratlr.utils;
 
 /**
@@ -6,5 +6,7 @@ package edu.kit.kastel.sdq.lissa.ratlr.utils;
  *
  * @param <F> The type of the first value in the pair
  * @param <S> The type of the second value in the pair
+ * @param first The first value of the pair
+ * @param second The second value of the pair
  */
 public record Pair<F, S>(F first, S second) {}


### PR DESCRIPTION
This PR addressed multiple minor javadoc warnings raised during `mvn javadoc:jar` runs.
 - Moves documentation for record parameters into class-level documentation
 - Adds missing parameter docs
 - Adds missing method docs